### PR TITLE
Feature/support for 5th and 7th versions of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: php
 
 php:
+  - 5.6
+  - 7.0
+  - 7.1
   - 7.2
 
 env:
+  - LARAVEL_VERSION=5.6.*
+  - LARAVEL_VERSION=5.7.*
   - LARAVEL_VERSION=5.8.*
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
-
+  - 7.3
+  
 env:
   - LARAVEL_VERSION=5.6.*
   - LARAVEL_VERSION=5.7.*


### PR DESCRIPTION
Laravel versioning support:
- 5.6.*
- 5.7.*
- 5.8.*

PHP versioning support:
- 7.1
- 7.2
- 7.3